### PR TITLE
Noviny/smarter file include

### DIFF
--- a/.changeset/4083273d/changes.json
+++ b/.changeset/4083273d/changes.json
@@ -1,0 +1,4 @@
+{
+  "releases": [{ "name": "@brisk-docs/website", "type": "patch" }],
+  "dependents": []
+}

--- a/.changeset/4083273d/changes.md
+++ b/.changeset/4083273d/changes.md
@@ -1,0 +1,1 @@
+The npm:include option for files meant we could accidentally publish our own `docs` and `guides` and `packages` folders - this would cause errors when someone else ran them. The ignore now only includes ts files, which solves this for us.

--- a/.changeset/b2de659c/changes.json
+++ b/.changeset/b2de659c/changes.json
@@ -1,0 +1,4 @@
+{
+  "releases": [{ "name": "@brisk-docs/website", "type": "patch" }],
+  "dependents": []
+}

--- a/.changeset/b2de659c/changes.md
+++ b/.changeset/b2de659c/changes.md
@@ -1,0 +1,1 @@
+When given a space in a docs section name, convert it to a dash, be a little bit safer with these names

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "eslint-plugin-emotion": "^10.0.7",
     "express": "^4.16.4",
     "extract-react-types-loader": "^0.3.0",
+    "filenamify": "^4.0.0",
     "fs-extra": "^7.0.1",
     "git-url-parse": "^11.1.2",
     "glob": "^7.1.3",

--- a/packages/website/CHANGELOG.md
+++ b/packages/website/CHANGELOG.md
@@ -11,6 +11,7 @@
 - f49a1e5: Code view in examples page is expandable/collapsible
 - 2dc8740: Added breadcrumbs to changelog page
 - 9b2744e: Added support for the root level README file
+- ccf1a90: Do not show folders in nav if they are empty
 - ccf1a90: Exclude files starting with \_ from page creation in the website
 - c3ec79f: Remove doc key prefix from table paths
 - 013cd06: Change breadcrumbs to use Next Links as custom components

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -78,6 +78,7 @@
     "emotion-server": "^9.2.12",
     "express": "^4.16.4",
     "extract-react-types-loader": "^0.3.0",
+    "filenamify": "^4.0.0",
     "fs-extra": "^7.0.1",
     "git-url-parse": "^11.1.2",
     "glob": "^7.1.3",

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -22,7 +22,7 @@
   },
   "files": [
     "src",
-    "pages",
+    "pages/*.tsx",
     "static",
     "custom-plugins",
     "babel.config.js",

--- a/packages/website/src/bin/page-generator/index.js
+++ b/packages/website/src/bin/page-generator/index.js
@@ -3,6 +3,8 @@ const fs = require('fs-extra');
 
 const rimraf = require('rimraf');
 const titleCase = require('title-case');
+const filenamify = require('filenamify');
+
 const getPackageInfo = require('./get-package-info');
 const getDocsInfo = require('./get-docs-info');
 const {
@@ -361,7 +363,13 @@ module.exports = async function generatePages(
 
   docsList.forEach(item => {
     const docsInfo = getDocsInfo(item.docsPath);
-    const pathName = item.name.toLowerCase();
+    const pathName = filenamify(
+      item.name
+        .toLowerCase()
+        .split(' ')
+        .join('-'),
+    );
+
     if (docsInfo) {
       docsSitemap[pathName] = generateProjectDocsPages(
         docsInfo,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5974,6 +5974,20 @@ file-loader@^3.0.1:
     loader-utils "^1.0.2"
     schema-utils "^1.0.0"
 
+filename-reserved-regex@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz#abf73dfab735d045440abfea2d91f389ebbfa229"
+  integrity sha1-q/c9+rc10EVECr/qLZHzieu/oik=
+
+filenamify@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/filenamify/-/filenamify-4.0.0.tgz#1f93b56e7340447bbb95f7f71ab9d9c4fa3d5393"
+  integrity sha512-orfNDs+RPrEO4RctQ6RwsMZHGH+lGxc671AZH60kHFf69NXCZtwU+l0cqs8nzyvcV47Hqq1nwRe5thi+/zRtow==
+  dependencies:
+    filename-reserved-regex "^2.0.0"
+    strip-outer "^1.0.1"
+    trim-repeated "^1.0.0"
+
 fileset@^2.0.3:
   version "2.0.3"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/fileset/-/fileset-2.0.3.tgz#8e7548a96d3cc2327ee5e674168723a333bba2a0"
@@ -11348,6 +11362,13 @@ strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
+strip-outer@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/strip-outer/-/strip-outer-1.0.1.tgz#b2fd2abf6604b9d1e6013057195df836b8a9d631"
+  integrity sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==
+  dependencies:
+    escape-string-regexp "^1.0.2"
+
 style-loader@^0.23.0:
   version "0.23.1"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/style-loader/-/style-loader-0.23.1.tgz#cb9154606f3e771ab6c4ab637026a1049174d925"
@@ -11728,6 +11749,13 @@ trim-lines@^1.0.0:
 trim-newlines@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-2.0.0.tgz#b403d0b91be50c331dfc4b82eeceb22c3de16d20"
+
+trim-repeated@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/trim-repeated/-/trim-repeated-1.0.0.tgz#e3646a2ea4e891312bf7eace6cfb05380bc01c21"
+  integrity sha1-42RqLqTokTEr9+rObPsFOAvAHCE=
+  dependencies:
+    escape-string-regexp "^1.0.2"
 
 trim-right@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Two fixes in this:
1) the `files` object is better so we are less likely to publish our test data
2) When the `name` for a docs section includes a space, we recover from that.