### PR TITLE
AFP-294: Use command line port option to start website

### DIFF
--- a/.changeset/aeea9d77/changes.json
+++ b/.changeset/aeea9d77/changes.json
@@ -1,0 +1,4 @@
+{
+  "releases": [{ "name": "@brisk-docs/website", "type": "patch" }],
+  "dependents": []
+}

--- a/.changeset/aeea9d77/changes.md
+++ b/.changeset/aeea9d77/changes.md
@@ -1,0 +1,1 @@
+Use custom port for website if provided

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ jobs:
 
       - run:
           name: Cypress Suite
-          command: node_modules/.bin/wait-on http://localhost:8080 && bolt cypress
+          command: node_modules/.bin/wait-on http://localhost:3000 && bolt cypress
 
 workflows:
   version: 2

--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,5 @@
 {
-  "baseUrl": "http://localhost:8080",
+  "baseUrl": "http://localhost:3000",
   "integrationFolder": "packages/website/cypress/integration",
   "fixturesFolder": "packages/website/cypress/fixtures",
   "screenshotsFolder": "packages/website/cypress/screenshots",

--- a/packages/website/src/bin/index.js
+++ b/packages/website/src/bin/index.js
@@ -18,6 +18,10 @@ const cliOptions = [
 ];
 const options = commandLineArgs(cliOptions, { argv, camelCase: true });
 
+const nextOptions =[];
+
+if (options.port) nextOptions.push(`--port ${options.port}`);
+
 if (mainOptions.command === undefined) {
   throw new Error(`No command supplied`);
 }
@@ -29,7 +33,7 @@ const handleError = err => {
 
 switch (mainOptions.command) {
   case 'dev': {
-    dev(options.config).catch(handleError);
+    dev(options.config, nextOptions).catch(handleError);
     break;
   }
   case 'build': {
@@ -37,7 +41,7 @@ switch (mainOptions.command) {
     break;
   }
   case 'start': {
-    start(options.config, options.port).catch(handleError);
+    start(options.config, nextOptions).catch(handleError);
     break;
   }
   case 'export': {

--- a/packages/website/src/bin/index.js
+++ b/packages/website/src/bin/index.js
@@ -14,11 +14,11 @@ const argv = mainOptions._unknown || [];
 
 const cliOptions = [
   { name: 'config', type: String },
-  { name: 'port', alias: 'p', type: Number }
+  { name: 'port', alias: 'p', type: Number },
 ];
 const options = commandLineArgs(cliOptions, { argv, camelCase: true });
 
-const nextOptions =[];
+const nextOptions = [];
 
 if (options.port) nextOptions.push(`--port ${options.port}`);
 

--- a/packages/website/src/bin/index.js
+++ b/packages/website/src/bin/index.js
@@ -12,7 +12,10 @@ const mainOptions = commandLineArgs(mainDefinitions, {
 // eslint-disable-next-line no-underscore-dangle
 const argv = mainOptions._unknown || [];
 
-const cliOptions = [{ name: 'config', type: String }];
+const cliOptions = [
+  { name: 'config', type: String },
+  { name: 'port', alias: 'p', type: Number }
+];
 const options = commandLineArgs(cliOptions, { argv, camelCase: true });
 
 if (mainOptions.command === undefined) {
@@ -34,7 +37,7 @@ switch (mainOptions.command) {
     break;
   }
   case 'start': {
-    start(options.config).catch(handleError);
+    start(options.config, options.port).catch(handleError);
     break;
   }
   case 'export': {

--- a/packages/website/src/bin/run-website.js
+++ b/packages/website/src/bin/run-website.js
@@ -50,8 +50,8 @@ const build = async configPath => {
   spawnNextProcess('build', configPath);
 };
 
-const start = async configPath => {
-  spawnNextProcess('start', configPath, '-p 8080');
+const start = async (configPath, port=3000) => {
+  spawnNextProcess('start', configPath, `-p ${port}`);
 };
 
 const exportWebsite = async configPath => {

--- a/packages/website/src/bin/run-website.js
+++ b/packages/website/src/bin/run-website.js
@@ -40,22 +40,22 @@ const preNextScripts = async configPath => {
   await generatePages(config);
 };
 
-const dev = async configPath => {
+const dev = async (configPath, nextOptions = []) => {
   await preNextScripts(configPath);
-  spawnNextProcess('dev', configPath);
+  spawnNextProcess('dev', configPath, ...nextOptions);
 };
 
-const build = async configPath => {
+const build = async (configPath, nextOptions = []) => {
   await preNextScripts(configPath);
-  spawnNextProcess('build', configPath);
+  spawnNextProcess('build', configPath, ...nextOptions);
 };
 
-const start = async (configPath, port=3000) => {
-  spawnNextProcess('start', configPath, `-p ${port}`);
+const start = async (configPath, nextOptions = []) => {
+  spawnNextProcess('start', configPath, ...nextOptions);
 };
 
-const exportWebsite = async configPath => {
-  spawnNextProcess('export', configPath, `-o ${path.join(cwd, 'out')}`);
+const exportWebsite = async (configPath, nextOptions = []) => {
+  spawnNextProcess('export', configPath, `-o ${path.join(cwd, 'out')}`, ...nextOptions);
 };
 
 module.exports.dev = dev;

--- a/packages/website/src/bin/run-website.js
+++ b/packages/website/src/bin/run-website.js
@@ -55,7 +55,12 @@ const start = async (configPath, nextOptions = []) => {
 };
 
 const exportWebsite = async (configPath, nextOptions = []) => {
-  spawnNextProcess('export', configPath, `-o ${path.join(cwd, 'out')}`, ...nextOptions);
+  spawnNextProcess(
+    'export',
+    configPath,
+    `-o ${path.join(cwd, 'out')}`,
+    ...nextOptions,
+  );
 };
 
 module.exports.dev = dev;


### PR DESCRIPTION
Ticket says we should be able to pass in Next options to any of our commands and have them passed through. I'd like to know what options these are, as the command-line-args package requires that all potential options be explicitly added by name.