### PR TITLE
Pyu/afp 319 resolve brisk console errors

### DIFF
--- a/.changeset/9b8f0e0f/changes.json
+++ b/.changeset/9b8f0e0f/changes.json
@@ -1,0 +1,4 @@
+{
+  "releases": [{ "name": "@brisk-docs/website", "type": "patch" }],
+  "dependents": []
+}

--- a/.changeset/9b8f0e0f/changes.md
+++ b/.changeset/9b8f0e0f/changes.md
@@ -1,0 +1,1 @@
+Fixed a number of console errors

--- a/packages/website/pages/index.tsx
+++ b/packages/website/pages/index.tsx
@@ -105,6 +105,7 @@ class HomePage extends React.Component {
                         .filter(x => x !== 'readme')
                         .map((key, i) => (
                           <Panel
+                            key={key}
                             href={`/${key}`}
                             {...this.getDocsPanelProps(context[i])}
                           />

--- a/packages/website/src/components/breadcrumbs.tsx
+++ b/packages/website/src/components/breadcrumbs.tsx
@@ -21,26 +21,25 @@ type NextLinkProps = {
   onMouseLeave: React.MouseEventHandler;
 };
 
-const NextLink = React.forwardRef(({
-  href,
-  className,
-  onMouseEnter,
-  onMouseLeave,
-  children,
-}: NextLinkProps, ref: React.Ref<HTMLAnchorElement>) => {
-  return (
-    <Link href={href}>
-      <a
-        ref={ref}
-        className={className}
-        onMouseEnter={onMouseEnter}
-        onMouseLeave={onMouseLeave}
-      >
-        {children}
-      </a>
-    </Link>
-  );
-});
+const NextLink = React.forwardRef(
+  (
+    { href, className, onMouseEnter, onMouseLeave, children }: NextLinkProps,
+    ref: React.Ref<HTMLAnchorElement>,
+  ) => {
+    return (
+      <Link href={href}>
+        <a
+          ref={ref}
+          className={className}
+          onMouseEnter={onMouseEnter}
+          onMouseLeave={onMouseLeave}
+        >
+          {children}
+        </a>
+      </Link>
+    );
+  },
+);
 
 type BreadcrumbsNavProps = {
   pagePath: string;

--- a/packages/website/src/components/breadcrumbs.tsx
+++ b/packages/website/src/components/breadcrumbs.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+/* eslint-disable react/no-multi-comp */
+import * as React from 'react';
 import titleCase from 'title-case';
 import Breadcrumbs, { BreadcrumbsItem } from '@atlaskit/breadcrumbs';
 import styled from '@emotion/styled';
@@ -20,16 +21,17 @@ type NextLinkProps = {
   onMouseLeave: React.MouseEventHandler;
 };
 
-const NextLink = ({
+const NextLink = React.forwardRef(({
   href,
   className,
   onMouseEnter,
   onMouseLeave,
   children,
-}: NextLinkProps) => {
+}: NextLinkProps, ref: React.Ref<HTMLAnchorElement>) => {
   return (
     <Link href={href}>
       <a
+        ref={ref}
         className={className}
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
@@ -38,7 +40,7 @@ const NextLink = ({
       </a>
     </Link>
   );
-};
+});
 
 type BreadcrumbsNavProps = {
   pagePath: string;
@@ -63,9 +65,9 @@ const BreadcrumbsNav = ({ pagePath }: BreadcrumbsNavProps) => {
               key={pages[idx]}
               href={path}
               text={titleCase(pages[idx])}
-              component={() => (
+              component={React.forwardRef(() => (
                 <p style={{ fontWeight: 'bold' }}>{titleCase(pages[idx])}</p>
-              )}
+              ))}
             />
           ) : (
             <BreadcrumbsItem

--- a/packages/website/src/components/mdx/code/inline.tsx
+++ b/packages/website/src/components/mdx/code/inline.tsx
@@ -5,4 +5,4 @@ export type Props = {
   children: string;
 };
 
-export default ({ children }: Props) => <AkCode text={children} />;
+export default ({ children }: Props) => <AkCode text={children} language="text" />;

--- a/packages/website/src/components/mdx/code/inline.tsx
+++ b/packages/website/src/components/mdx/code/inline.tsx
@@ -5,4 +5,6 @@ export type Props = {
   children: string;
 };
 
-export default ({ children }: Props) => <AkCode text={children} language="text" />;
+export default ({ children }: Props) => (
+  <AkCode text={children} language="text" />
+);

--- a/packages/website/src/components/page-templates/documents-index.js
+++ b/packages/website/src/components/page-templates/documents-index.js
@@ -95,5 +95,9 @@ const Docs = ({ data }) => (
   </>
 );
 
-Docs.propTypes = { data: { key: PropTypes.string } };
+Docs.propTypes = {
+  data: PropTypes.shape({
+    key: PropTypes.string
+  }),
+};
 export default Docs;

--- a/packages/website/src/components/page-templates/documents-index.js
+++ b/packages/website/src/components/page-templates/documents-index.js
@@ -97,7 +97,7 @@ const Docs = ({ data }) => (
 
 Docs.propTypes = {
   data: PropTypes.shape({
-    key: PropTypes.string
+    key: PropTypes.string,
   }),
 };
 export default Docs;

--- a/packages/website/src/components/page-templates/item-list.js
+++ b/packages/website/src/components/page-templates/item-list.js
@@ -135,7 +135,7 @@ ItemList.propTypes = {
       PropTypes.shape({
         id: PropTypes.string.isRequired,
         pagePath: PropTypes.string.isRequired,
-        pageType: PropTypes.string.isRequired,
+        pageType: PropTypes.string,
         pageTitle: PropTypes.string,
       }),
     ),

--- a/packages/website/src/components/page-templates/package-example.js
+++ b/packages/website/src/components/page-templates/package-example.js
@@ -208,7 +208,7 @@ PackageExample.propTypes = {
   }).isRequired,
   children: PropTypes.arrayOf(
     PropTypes.shape({
-      key: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired,
       component: PropTypes.node.isRequired,
     }),
   ).isRequired,

--- a/packages/website/src/components/page-templates/package-home.js
+++ b/packages/website/src/components/page-templates/package-home.js
@@ -109,9 +109,10 @@ PackageHome.propTypes = {
     repository: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.shape({
-      url: PropTypes.string.isRequired,
-      directory: PropTypes.string,
-    })]),
+        url: PropTypes.string.isRequired,
+        directory: PropTypes.string,
+      }),
+    ]),
     pageTitle: PropTypes.string,
   }).isRequired,
   children: PropTypes.node,

--- a/packages/website/src/components/page-templates/package-home.js
+++ b/packages/website/src/components/page-templates/package-home.js
@@ -106,10 +106,12 @@ PackageHome.propTypes = {
     description: PropTypes.string,
     version: PropTypes.string.isRequired,
     maintainers: PropTypes.arrayOf(PropTypes.string),
-    repository: PropTypes.shape({
+    repository: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.shape({
       url: PropTypes.string.isRequired,
       directory: PropTypes.string,
-    }).isRequired,
+    })]),
     pageTitle: PropTypes.string,
   }).isRequired,
   children: PropTypes.node,


### PR DESCRIPTION
A good amount of errors have been fixed, although there are still some remaining:
- setting state in package-example causes warning because global nav seems to be unmounting
- prop `className` did not match between server and client
- prop `data-react-beautiful-dnd-draggable` did not match between server and client
- Language shell not supported (bug in AkCodeBlock)
