### PR TITLE
AFP-329 Fix broken links on package home pages

### DIFF
--- a/.changeset/shy-moles-switch/changes.json
+++ b/.changeset/shy-moles-switch/changes.json
@@ -1,0 +1,4 @@
+{
+  "releases": [{ "name": "@brisk-docs/website", "type": "patch" }],
+  "dependents": []
+}

--- a/.changeset/shy-moles-switch/changes.md
+++ b/.changeset/shy-moles-switch/changes.md
@@ -1,0 +1,1 @@
+Fix broken relative links on package home pages

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,6 @@
 node_modules
 .next
+out
 
 packages/website/pages/packages
 packages/website/pages/docs

--- a/packages/website/dummy-data/simple-project/packages/mock-package1/README.md
+++ b/packages/website/dummy-data/simple-project/packages/mock-package1/README.md
@@ -20,6 +20,8 @@ These instructions will get you a copy of the project up and running on your loc
 development and testing purposes. See deployment for notes on how to deploy the project on a live
 system.
 
+[Link to extended info](./docs/extended-info.md)
+
 ### Prerequisites
 
 What things you need to install the software and how to install them

--- a/packages/website/src/components/common/page-status-context.tsx
+++ b/packages/website/src/components/common/page-status-context.tsx
@@ -1,0 +1,12 @@
+import { createContext } from 'react';
+
+export type PageStatus = {
+  /** Whether the page has been converted from a non-index file such as a README into an index page.
+   * This affects how relative directory paths in markdown is transformed into a link on the website.
+   */
+  convertedToDir: false;
+};
+
+export const PageStatusContext = createContext<PageStatus>({
+  convertedToDir: false,
+});

--- a/packages/website/src/components/page-templates/package-home.js
+++ b/packages/website/src/components/page-templates/package-home.js
@@ -5,6 +5,7 @@ import { colors } from '@atlaskit/theme';
 import SectionMessage from '@atlaskit/section-message';
 import titleCase from 'title-case';
 
+import { PageStatusContext } from '../common/page-status-context';
 import NavigationWrapper from '../navigation-wrapper';
 import Wrapper from '../content-style-wrapper';
 import PackageNavContent from '../navigation/package-nav-content';
@@ -67,6 +68,10 @@ const MissingReadmeWarning = () => (
   </SectionMessage>
 );
 
+const pageStatusValue = {
+  convertedToDir: true,
+};
+
 const PackageHome = ({ data, children }) => {
   return (
     <>
@@ -79,21 +84,24 @@ const PackageHome = ({ data, children }) => {
           />
         )}
       >
-        <Wrapper pagePath={data.pagePath}>
-          <Header id={data.id} heading={titleCase(data.packageName)} />
-          <Description>{data.description}</Description>
-          <PackageMetaData
-            id={data.id}
-            version={data.version}
-            maintainers={data.maintainers}
-            repository={data.repository}
-          />
-          {children || process.env.NODE_ENV !== 'development' ? (
-            children
-          ) : (
-            <MissingReadmeWarning />
-          )}
-        </Wrapper>
+        <PageStatusContext.Provider value={pageStatusValue}>
+          <Wrapper pagePath={data.pagePath}>
+            <Header id={data.id} heading={titleCase(data.packageName)} />
+            <Description>{data.description}</Description>
+            <PackageMetaData
+              id={data.id}
+              version={data.version}
+              maintainers={data.maintainers}
+              repository={data.repository}
+            />
+
+            {children || process.env.NODE_ENV !== 'development' ? (
+              children
+            ) : (
+              <MissingReadmeWarning />
+            )}
+          </Wrapper>
+        </PageStatusContext.Provider>
       </NavigationWrapper>
     </>
   );

--- a/packages/website/src/components/page-templates/package-home.test.js
+++ b/packages/website/src/components/page-templates/package-home.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { shallow, mount } from 'enzyme';
 import titleCase from 'title-case';
 import PackageHomeWrapper, { Description } from './package-home';
+import { PageStatusContext } from '../common/page-status-context';
 
 jest.mock('../navigation/package-nav-content', () => () => <div />);
 /* eslint-disable react/prop-types */
@@ -87,5 +88,18 @@ describe('package home wrapper component', () => {
         .children()
         .text(),
     ).toEqual(data.description);
+  });
+
+  it('should render a page status provider with convertedToDir set to true', () => {
+    const wrapper = shallow(
+      <PackageHomeWrapper data={data}>
+        <div>Hello</div>
+      </PackageHomeWrapper>,
+    );
+
+    const PageStatusProvider = wrapper.find(PageStatusContext.Provider);
+
+    expect(PageStatusProvider).toHaveLength(1);
+    expect(PageStatusProvider.prop('value')).toEqual({ convertedToDir: true });
   });
 });

--- a/packages/website/src/components/switch-link.tsx
+++ b/packages/website/src/components/switch-link.tsx
@@ -1,6 +1,22 @@
 import * as React from 'react';
 import Link from 'next/link';
+import { withRouter, SingletonRouter } from 'next/router';
 import * as PropTypes from 'prop-types';
+import { PageStatusContext } from './common/page-status-context';
+
+const urlHasTrailingSlash = (router: SingletonRouter) => {
+  if (!router.asPath) {
+    return null;
+  }
+
+  const pathnameLength = router.pathname.length;
+  const pathnameIndex = router.asPath.indexOf(router.pathname);
+  if (pathnameIndex === -1) {
+    return null;
+  }
+
+  return router.asPath[pathnameIndex + pathnameLength] === '/';
+};
 
 /*
 This link component is designed to contextually be either a straight anchor
@@ -13,9 +29,10 @@ anchor, as it means you don't have to think about this problem space.
 export type Props = {
   href: string;
   children: React.ReactChild;
+  router?: SingletonRouter;
 };
 
-const SwitchLink = ({ href, children, ...rest }: Props) => {
+const SwitchLink = ({ href, children, router, ...rest }: Props) => {
   if (!href || href.indexOf('http') === 0 || href.indexOf('#') === 0) {
     return (
       <a href={href} {...rest}>
@@ -26,6 +43,8 @@ const SwitchLink = ({ href, children, ...rest }: Props) => {
 
   let newHref = href.replace(/\.md$/, '');
 
+  const { convertedToDir = false } = React.useContext(PageStatusContext);
+
   /*
   Fun Fact: Next does not (and won't) handle relative links in exports.
 
@@ -33,12 +52,34 @@ const SwitchLink = ({ href, children, ...rest }: Props) => {
 
   In the future, I would like to move this to the build step to convert
   relative links.
+
+  Assumption: We are assuming if the node env is production then we are in
+  a statically exported next app.
+
+  `convertedToDir` is set to true when a README page has been converted to an
+  indexed page, e.g. package home. In this case, we actually require the additional
+  slash that next adds as part of its export so we can skip link surgery.
   */
-  if (process.env.NODE_ENV === 'production') {
+  if (process.env.NODE_ENV === 'production' && !convertedToDir) {
     if (newHref.startsWith('./')) {
       newHref = newHref.replace('./', '../');
     } else if (newHref.startsWith('../')) {
       newHref = newHref.replace('../', '../../');
+    }
+  } else if (process.env.NODE_ENV !== 'production' && convertedToDir) {
+    /* In dev (non-export) mode, URLs work both with and without trailing slash URLs.
+     * Relative links in pages that have been converted to directories will only work when
+     * the URL contains a trailing slash, so modify the relative link if the current URL does
+     * not have one.
+     * This should ideally be fixed by enforcing trailing or non-trailing slashed URLs */
+    if (
+      newHref.startsWith('.') &&
+      router &&
+      urlHasTrailingSlash(router) === false
+    ) {
+      const urlSegments = router.pathname.split('/');
+      const lastUrlSegment = urlSegments[urlSegments.length - 1];
+      newHref = `./${lastUrlSegment}/${newHref}`;
     }
   }
 
@@ -52,6 +93,7 @@ const SwitchLink = ({ href, children, ...rest }: Props) => {
 SwitchLink.propTypes = {
   href: PropTypes.string.isRequired,
   children: PropTypes.node.isRequired,
+  router: PropTypes.any,
 };
 
-export default SwitchLink;
+export default withRouter(SwitchLink as any) as SwitchLink;

--- a/packages/website/src/components/switch-link.tsx
+++ b/packages/website/src/components/switch-link.tsx
@@ -93,7 +93,10 @@ const SwitchLink = ({ href, children, router, ...rest }: Props) => {
 SwitchLink.propTypes = {
   href: PropTypes.string.isRequired,
   children: PropTypes.node.isRequired,
-  router: PropTypes.any,
+  router: PropTypes.shape({
+    asPath: PropTypes.string,
+    pathname: PropTypes.string,
+  }),
 };
 
 export default withRouter(SwitchLink as any) as SwitchLink;


### PR DESCRIPTION
This is achieved by introducing a PageStatus context component that
notifies the SwitchLink component when it is inside a page that has been
moved from a README file into a directory URL without the readme path.
The SwitchLink can then factor that into the href manipulation to ensure
relative links still work correctly.