### PR TITLE
AFP-322 Custom sort order within a directory

### DIFF
--- a/.changeset/eleven-hornets-design/changes.json
+++ b/.changeset/eleven-hornets-design/changes.json
@@ -1,0 +1,4 @@
+{
+  "releases": [{ "name": "@brisk-docs/website", "type": "patch" }],
+  "dependents": []
+}

--- a/.changeset/eleven-hornets-design/changes.md
+++ b/.changeset/eleven-hornets-design/changes.md
@@ -1,0 +1,1 @@
+Add ability to specify custom sort order of docs within a directory via nested docs.config.js. See the [configuration](./docs/configuration.md) docs for more details.

--- a/packages/website/__fixtures__/mock-docs-with-sorting/docs/doc-1.md
+++ b/packages/website/__fixtures__/mock-docs-with-sorting/docs/doc-1.md
@@ -1,0 +1,1 @@
+# This is doc 1

--- a/packages/website/__fixtures__/mock-docs-with-sorting/docs/doc-2.md
+++ b/packages/website/__fixtures__/mock-docs-with-sorting/docs/doc-2.md
@@ -1,0 +1,1 @@
+# This is doc 2

--- a/packages/website/__fixtures__/mock-docs-with-sorting/docs/doc-3/doc-3-1.md
+++ b/packages/website/__fixtures__/mock-docs-with-sorting/docs/doc-3/doc-3-1.md
@@ -1,0 +1,1 @@
+# This is doc 1 nested in doc-3

--- a/packages/website/__fixtures__/mock-docs-with-sorting/docs/doc-3/doc-3-2/doc-3-2-1.md
+++ b/packages/website/__fixtures__/mock-docs-with-sorting/docs/doc-3/doc-3-2/doc-3-2-1.md
@@ -1,0 +1,3 @@
+# This is doc 1 inside doc 2 inside doc 3
+
+#docception

--- a/packages/website/__fixtures__/mock-docs-with-sorting/docs/doc-3/docs.config.js
+++ b/packages/website/__fixtures__/mock-docs-with-sorting/docs/doc-3/docs.config.js
@@ -1,0 +1,3 @@
+module.exports = () => ({
+  sortOrder: ['*', 'doc-3-1'],
+});

--- a/packages/website/__fixtures__/mock-docs-with-sorting/docs/docs.config.js
+++ b/packages/website/__fixtures__/mock-docs-with-sorting/docs/docs.config.js
@@ -1,0 +1,3 @@
+module.exports = () => ({
+  sortOrder: ['doc-2'],
+});

--- a/packages/website/docs/configuration.md
+++ b/packages/website/docs/configuration.md
@@ -18,3 +18,28 @@ the returned object may have the following properties:
 | docs     | Path to the directory where project docs live                                                                                       |
 | siteName | Display name for the project as displayed in the website                                                                            |
 | webpack  | A function used to customise the website's webpack configuration. see [Configuring webpack](./configuring-webpack) for more details |
+
+## Nested configuration
+
+Nested configuration is also supported for cases where you'd like to configure things on a per-directory basis.
+
+The available options in a nested `docs.configs.js` file are:
+
+### sortOrder
+
+Type: `string[]`
+
+Here you can customise the sort order of docs within a specific directory. This will affect in what order they are displayed in the navigation and index page tables.
+
+To use this, provide a list of doc dirnames/filenames (without their extension) to set the ascending sort order. Any file that isn't listed in the array will be sorted after them using the default alphabetical sorting. You can also pass a wildcard `'*'` value to configure where the files that aren't listed should go. This is useful for specifying documentation to always be listed at the bottom without having to explicitly list every other docs file.
+
+E.g.
+
+```js
+sortOrder: [
+  'something-very-important',
+  'second-most-important',
+  '*',
+  'should-display-after-everything-else',
+];
+```

--- a/packages/website/dummy-data/simple-project/docs/guides/docs.config.js
+++ b/packages/website/dummy-data/simple-project/docs/guides/docs.config.js
@@ -1,0 +1,3 @@
+module.exports = () => ({
+  sortOrder: ['nifty-tricks', 'how-to-be-accomplished'],
+});

--- a/packages/website/dummy-data/simple-project/packages/mock-package1/docs/docs.config.js
+++ b/packages/website/dummy-data/simple-project/packages/mock-package1/docs/docs.config.js
@@ -1,0 +1,3 @@
+module.exports = () => ({
+  sortOrder: ['special-usecase'],
+});

--- a/packages/website/dummy-data/simple-project/packages/mock-package2/docs/docs.config.js
+++ b/packages/website/dummy-data/simple-project/packages/mock-package2/docs/docs.config.js
@@ -1,0 +1,3 @@
+module.exports = () => ({
+  sortOrder: ['special-usecase', '*'],
+});

--- a/packages/website/dummy-data/simple-project/packages/mock-package3/docs/docs.config.js
+++ b/packages/website/dummy-data/simple-project/packages/mock-package3/docs/docs.config.js
@@ -1,0 +1,3 @@
+module.exports = () => ({
+  sortOrder: ['*', 'extended-info'],
+});

--- a/packages/website/src/bin/page-generator/get-docs-info.test.js
+++ b/packages/website/src/bin/page-generator/get-docs-info.test.js
@@ -121,3 +121,35 @@ describe('Test exclude everything that are non md files', () => {
     });
   });
 });
+
+describe('Custom doc sorting', () => {
+  let cwd;
+  let docsInfo;
+
+  beforeAll(async () => {
+    cwd = await copyFixtureIntoTempDir(__dirname, 'mock-docs-with-sorting');
+    docsInfo = getDocsInfo(path.join(cwd, 'docs'));
+  });
+
+  it('sorts doc-2 before doc-1 in top-level docs folder', () => {
+    expect(docsInfo[0]).toMatchObject({
+      id: 'doc-2',
+    });
+    expect(docsInfo[1]).toMatchObject({
+      id: 'doc-1',
+    });
+    expect(docsInfo[2]).toMatchObject({
+      id: 'doc-3',
+    });
+  });
+
+  it('sorts nested doc-3-2 before doc-3-1', () => {
+    const docs3Children = docsInfo[2].children;
+    expect(docs3Children[0]).toMatchObject({
+      id: 'doc-3-2',
+    });
+    expect(docs3Children[1]).toMatchObject({
+      id: 'doc-3-1',
+    });
+  });
+});

--- a/packages/website/src/components/page-templates/item-list.js
+++ b/packages/website/src/components/page-templates/item-list.js
@@ -89,12 +89,7 @@ const ItemList = ({ data }) => {
       <Page>
         <Title>{title}</Title>
         <Section>
-          <Table
-            head={head}
-            rows={getRows()}
-            defaultSortKey="name"
-            defaultSortOrder="ASC"
-          />
+          <Table head={head} rows={getRows()} />
         </Section>
       </Page>
     );


### PR DESCRIPTION
Add ability to specify custom sort order of docs within a directory via nested docs.config.js. See the configuration docs for more details.