### PR TITLE
Page generation test refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules
 .next
 .DS_Store
 .idea
+.vscode
 
 package-lock.json
 yarn-error.log

--- a/packages/website/src/bin/page-generator/__snapshots__/test.js.snap
+++ b/packages/website/src/bin/page-generator/__snapshots__/test.js.snap
@@ -24,6 +24,33 @@ export default () => (
 );
 `;
 
+exports[`Generate pages docs pages generation creates an index/home page for each level of nesting 1`] = `
+import React from 'react';
+import Wrapper from '../../jest-fixture/documents-index';
+
+export default () => (
+  <Wrapper data={{"key":"docs","pagePath":"docs/index.js","pageTitle":"docs","pageType":"docs"}} />
+);
+`;
+
+exports[`Generate pages docs pages generation creates an index/home page for each level of nesting 2`] = `
+import React from 'react';
+import Wrapper from '../../../jest-fixture/item-list';
+
+export default () => (
+  <Wrapper data={{"key":"docs","id":"doc-3","children":[{"id":"doc-3-1","pagePath":"doc-3/doc-3-1"},{"id":"doc-3-2","pagePath":"doc-3/doc-3-2"}],"pagePath":"docs/doc-3/index.js","pageTitle":"Documents","pageType":"docs"}} />
+);
+`;
+
+exports[`Generate pages docs pages generation creates an index/home page for each level of nesting 3`] = `
+import React from 'react';
+import Wrapper from '../../../../jest-fixture/item-list';
+
+export default () => (
+  <Wrapper data={{"key":"docs","id":"doc-3-2","children":[{"id":"doc-3-2-1","pagePath":"doc-3-2/doc-3-2-1"}],"pagePath":"docs/doc-3/doc-3-2/index.js","pageTitle":"Documents","pageType":"docs"}} />
+);
+`;
+
 exports[`Generate pages docs pages generation creates pages for each markdown file 1`] = `
 import React from 'react';
 import Component from '../../jest-fixture/docs/doc-1.md';

--- a/packages/website/src/bin/page-generator/__snapshots__/test.js.snap
+++ b/packages/website/src/bin/page-generator/__snapshots__/test.js.snap
@@ -1,0 +1,562 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Additional items in the docs tests creates pages for each markdown file in docs and guides folder 1`] = `
+import React from 'react';
+import Component from '../../jest-fixture/docs/testdoc.md';
+import Wrapper from '../../jest-fixture/project-docs';
+
+export default () => (
+  <Wrapper data={{"key":"docs","pagePath":"docs/testdoc.js","pageTitle":"Testdoc"}}>
+      <Component />
+  </Wrapper>
+);
+`;
+
+exports[`Additional items in the docs tests creates pages for each markdown file in docs and guides folder 2`] = `
+import React from 'react';
+import Component from '../../jest-fixture/guides/testguide.md';
+import Wrapper from '../../jest-fixture/project-docs';
+
+export default () => (
+  <Wrapper data={{"key":"guides","pagePath":"guides/testguide.js","pageTitle":"Testguide"}}>
+      <Component />
+  </Wrapper>
+);
+`;
+
+exports[`Generate pages docs pages generation creates pages for each markdown file 1`] = `
+import React from 'react';
+import Component from '../../jest-fixture/docs/doc-1.md';
+import Wrapper from '../../jest-fixture/project-docs';
+
+export default () => (
+  <Wrapper data={{"key":"docs","pagePath":"docs/doc-1.js","pageTitle":"Doc 1"}}>
+      <Component />
+  </Wrapper>
+);
+`;
+
+exports[`Generate pages docs pages generation creates pages for each markdown file 2`] = `
+import React from 'react';
+import Component from '../../jest-fixture/docs/doc-2.md';
+import Wrapper from '../../jest-fixture/project-docs';
+
+export default () => (
+  <Wrapper data={{"key":"docs","pagePath":"docs/doc-2.js","pageTitle":"Doc 2"}}>
+      <Component />
+  </Wrapper>
+);
+`;
+
+exports[`Generate pages docs pages generation creates pages for each markdown file 3`] = `
+import React from 'react';
+import Component from '../../../jest-fixture/docs/doc-3/doc-3-1.md';
+import Wrapper from '../../../jest-fixture/project-docs';
+
+export default () => (
+  <Wrapper data={{"key":"docs","pagePath":"docs/doc-3/doc-3-1.js","pageTitle":"Doc 3 1"}}>
+      <Component />
+  </Wrapper>
+);
+`;
+
+exports[`Generate pages docs pages generation creates pages for each markdown file 4`] = `
+import React from 'react';
+import Component from '../../../../jest-fixture/docs/doc-3/doc-3-2/doc-3-2-1.md';
+import Wrapper from '../../../../jest-fixture/project-docs';
+
+export default () => (
+  <Wrapper data={{"key":"docs","pagePath":"docs/doc-3/doc-3-2/doc-3-2-1.js","pageTitle":"Doc 3 2 1"}}>
+      <Component />
+  </Wrapper>
+);
+`;
+
+exports[`Generate pages docs pages generation with differing name and path creates pages for each markdown file based on docsPath rather than name 1`] = `
+import React from 'react';
+import Component from '../../jest-fixture/guides/testguide.md';
+import Wrapper from '../../jest-fixture/project-docs';
+
+export default () => (
+  <Wrapper data={{"key":"cool-doc-stuff","pagePath":"guides/testguide.js","pageTitle":"Testguide"}}>
+      <Component />
+  </Wrapper>
+);
+`;
+
+exports[`Generate pages package pages generation creates a home page per package 1`] = `
+import React from 'react';
+import Component from '../../../jest-fixture/packages/mock-package1/README.md';
+import Wrapper from '../../../jest-fixture/package-home';
+
+export default () => (
+  <Wrapper data={{"id":"mock-package1","packageName":"mock-package-1","description":"This is a mock package to be used for doc website","version":"1.0.0","pagePath":"packages/mock-package1/index.js","pageTitle":"Mock Package1"}}>
+      <Component />
+  </Wrapper>
+);
+`;
+
+exports[`Generate pages package pages generation creates a home page per package 2`] = `
+import React from 'react';
+import Component from '../../../jest-fixture/packages/mock-package2/README.md';
+import Wrapper from '../../../jest-fixture/package-home';
+
+export default () => (
+  <Wrapper data={{"id":"mock-package2","packageName":"mock-package-2","description":"This is a mock package2 to be used for doc website","version":"1.0.0","pagePath":"packages/mock-package2/index.js","pageTitle":"Mock Package2"}}>
+      <Component />
+  </Wrapper>
+);
+`;
+
+exports[`Generate pages package pages generation creates a home page per package 3`] = `
+import React from 'react';
+import Component from '../../../jest-fixture/packages/mock-package2/README.md';
+import Wrapper from '../../../jest-fixture/package-home';
+
+export default () => (
+  <Wrapper data={{"id":"mock-package2","packageName":"mock-package-2","description":"This is a mock package2 to be used for doc website","version":"1.0.0","pagePath":"packages/mock-package2/index.js","pageTitle":"Mock Package2"}}>
+      <Component />
+  </Wrapper>
+);
+`;
+
+exports[`Generate pages package pages generation creates docs pages for each package: mock-package1 1`] = `
+import React from 'react';
+import Wrapper from '../../../../jest-fixture/item-list';
+
+export default () => (
+  <Wrapper data={{"id":"mock-package1","packageName":"mock-package-1","pagePath":"packages/mock-package1/docs/index.js","pageTitle":"Documents","pageType":"docs"}} />
+);
+`;
+
+exports[`Generate pages package pages generation creates docs pages for each package: mock-package1 2`] = `
+import React from 'react';
+import Component from '../../../../jest-fixture/packages/mock-package1/docs/extended-info.md';
+import Wrapper from '../../../../jest-fixture/package-docs';
+
+export default () => (
+  <Wrapper data={{"id":"mock-package1","packageName":"mock-package-1","pagePath":"packages/mock-package1/docs/extended-info.js","pageTitle":"Extended Info"}}>
+      <Component />
+  </Wrapper>
+);
+`;
+
+exports[`Generate pages package pages generation creates docs pages for each package: mock-package1 3`] = `
+import React from 'react';
+import Component from '../../../../jest-fixture/packages/mock-package1/docs/special-usecase.mdx';
+import Wrapper from '../../../../jest-fixture/package-docs';
+
+export default () => (
+  <Wrapper data={{"id":"mock-package1","packageName":"mock-package-1","pagePath":"packages/mock-package1/docs/special-usecase.js","pageTitle":"Special Usecase"}}>
+      <Component />
+  </Wrapper>
+);
+`;
+
+exports[`Generate pages package pages generation creates docs pages for each package: mock-package2 1`] = `
+import React from 'react';
+import Wrapper from '../../../../jest-fixture/item-list';
+
+export default () => (
+  <Wrapper data={{"id":"mock-package2","packageName":"mock-package-2","pagePath":"packages/mock-package2/docs/index.js","pageTitle":"Documents","pageType":"docs"}} />
+);
+`;
+
+exports[`Generate pages package pages generation creates docs pages for each package: mock-package2 2`] = `
+import React from 'react';
+import Component from '../../../../jest-fixture/packages/mock-package2/docs/extended-info.md';
+import Wrapper from '../../../../jest-fixture/package-docs';
+
+export default () => (
+  <Wrapper data={{"id":"mock-package2","packageName":"mock-package-2","pagePath":"packages/mock-package2/docs/extended-info.js","pageTitle":"Extended Info"}}>
+      <Component />
+  </Wrapper>
+);
+`;
+
+exports[`Generate pages package pages generation creates docs pages for each package: mock-package2 3`] = `
+import React from 'react';
+import Component from '../../../../jest-fixture/packages/mock-package2/docs/special-usecase.mdx';
+import Wrapper from '../../../../jest-fixture/package-docs';
+
+export default () => (
+  <Wrapper data={{"id":"mock-package2","packageName":"mock-package-2","pagePath":"packages/mock-package2/docs/special-usecase.js","pageTitle":"Special Usecase"}}>
+      <Component />
+  </Wrapper>
+);
+`;
+
+exports[`Generate pages package pages generation creates docs pages for each package: mock-package3 1`] = `
+import React from 'react';
+import Wrapper from '../../../../jest-fixture/item-list';
+
+export default () => (
+  <Wrapper data={{"id":"mock-package3","packageName":"mock-package-3","pagePath":"packages/mock-package3/docs/index.js","pageTitle":"Documents","pageType":"docs"}} />
+);
+`;
+
+exports[`Generate pages package pages generation creates docs pages for each package: mock-package3 2`] = `
+import React from 'react';
+import Component from '../../../../jest-fixture/packages/mock-package3/docs/extended-info.md';
+import Wrapper from '../../../../jest-fixture/package-docs';
+
+export default () => (
+  <Wrapper data={{"id":"mock-package3","packageName":"mock-package-3","pagePath":"packages/mock-package3/docs/extended-info.js","pageTitle":"Extended Info"}}>
+      <Component />
+  </Wrapper>
+);
+`;
+
+exports[`Generate pages package pages generation creates docs pages for each package: mock-package3 3`] = `
+import React from 'react';
+import Component from '../../../../jest-fixture/packages/mock-package3/docs/special-usecase.mdx';
+import Wrapper from '../../../../jest-fixture/package-docs';
+
+export default () => (
+  <Wrapper data={{"id":"mock-package3","packageName":"mock-package-3","pagePath":"packages/mock-package3/docs/special-usecase.js","pageTitle":"Special Usecase"}}>
+      <Component />
+  </Wrapper>
+);
+`;
+
+exports[`Generate pages package pages generation creates examples pages for each package 1`] = `
+import React from 'react';
+import Wrapper from '../../../../jest-fixture/item-list';
+
+export default () => (
+  <Wrapper data={{"id":"mock-package1","packageName":"mock-package-1","pagePath":"packages/mock-package1/examples/index.js","pageTitle":"Examples","pageType":"examples"}} />
+);
+`;
+
+exports[`Generate pages package pages generation creates examples pages for each package 2`] = `
+import React from 'react';
+import dynamic from 'next/dynamic';
+import fileContents from '!!raw-loader!../../../../jest-fixture/packages/mock-package1/examples/example1';
+import Wrapper from '../../../../jest-fixture/package-example';
+
+const DynamicComponent = dynamic(import('../../../../jest-fixture/packages/mock-package1/examples/example1')
+.then(Components => {
+return () => ( 
+<Wrapper data={{"id":"mock-package1","packageName":"mock-package-1","isolatedPath":"/packages/mock-package1/examples/isolated/example1","pageTitle":"Example1"}} fileContents={fileContents}>
+      {
+        [{ 
+            name: 'default', 
+            component: <Components.default /> 
+          }, 
+          ...Object.keys(Components).filter(componentName => componentName !== 'default')
+          .map(componentName => {
+            const Component = Components[componentName];
+            return {
+              name: componentName,
+              component: <Component />
+            }
+          })
+        ]
+      }
+  </Wrapper>
+  )
+}));
+export default () => <DynamicComponent/>
+`;
+
+exports[`Generate pages package pages generation creates examples pages for each package 3`] = `
+import React from 'react';
+import dynamic from 'next/dynamic';
+import fileContents from '!!raw-loader!../../../../jest-fixture/packages/mock-package1/examples/example2';
+import Wrapper from '../../../../jest-fixture/package-example';
+
+const DynamicComponent = dynamic(import('../../../../jest-fixture/packages/mock-package1/examples/example2')
+.then(Components => {
+return () => ( 
+<Wrapper data={{"id":"mock-package1","packageName":"mock-package-1","isolatedPath":"/packages/mock-package1/examples/isolated/example2","pageTitle":"Example2"}} fileContents={fileContents}>
+      {
+        [{ 
+            name: 'default', 
+            component: <Components.default /> 
+          }, 
+          ...Object.keys(Components).filter(componentName => componentName !== 'default')
+          .map(componentName => {
+            const Component = Components[componentName];
+            return {
+              name: componentName,
+              component: <Component />
+            }
+          })
+        ]
+      }
+  </Wrapper>
+  )
+}));
+export default () => <DynamicComponent/>
+`;
+
+exports[`Generate pages package pages generation creates examples pages for each package 4`] = `
+import React from 'react';
+import dynamic from 'next/dynamic';
+import fileContents from '!!raw-loader!../../../../jest-fixture/packages/mock-package1/examples/example3';
+import Wrapper from '../../../../jest-fixture/package-example';
+
+const DynamicComponent = dynamic(import('../../../../jest-fixture/packages/mock-package1/examples/example3')
+.then(Components => {
+return () => ( 
+<Wrapper data={{"id":"mock-package1","packageName":"mock-package-1","isolatedPath":"/packages/mock-package1/examples/isolated/example3","pageTitle":"Example3"}} fileContents={fileContents}>
+      {
+        [{ 
+            name: 'default', 
+            component: <Components.default /> 
+          }, 
+          ...Object.keys(Components).filter(componentName => componentName !== 'default')
+          .map(componentName => {
+            const Component = Components[componentName];
+            return {
+              name: componentName,
+              component: <Component />
+            }
+          })
+        ]
+      }
+  </Wrapper>
+  )
+}));
+export default () => <DynamicComponent/>
+`;
+
+exports[`Generate pages package pages generation creates examples pages for each package 5`] = `
+import React from 'react';
+import Wrapper from '../../../../jest-fixture/item-list';
+
+export default () => (
+  <Wrapper data={{"id":"mock-package2","packageName":"mock-package-2","pagePath":"packages/mock-package2/examples/index.js","pageTitle":"Examples","pageType":"examples"}} />
+);
+`;
+
+exports[`Generate pages package pages generation creates examples pages for each package 6`] = `
+import React from 'react';
+import dynamic from 'next/dynamic';
+import fileContents from '!!raw-loader!../../../../jest-fixture/packages/mock-package2/examples/example1';
+import Wrapper from '../../../../jest-fixture/package-example';
+
+const DynamicComponent = dynamic(import('../../../../jest-fixture/packages/mock-package2/examples/example1')
+.then(Components => {
+return () => ( 
+<Wrapper data={{"id":"mock-package2","packageName":"mock-package-2","isolatedPath":"/packages/mock-package2/examples/isolated/example1","pageTitle":"Example1"}} fileContents={fileContents}>
+      {
+        [{ 
+            name: 'default', 
+            component: <Components.default /> 
+          }, 
+          ...Object.keys(Components).filter(componentName => componentName !== 'default')
+          .map(componentName => {
+            const Component = Components[componentName];
+            return {
+              name: componentName,
+              component: <Component />
+            }
+          })
+        ]
+      }
+  </Wrapper>
+  )
+}));
+export default () => <DynamicComponent/>
+`;
+
+exports[`Generate pages package pages generation creates examples pages for each package 7`] = `
+import React from 'react';
+import dynamic from 'next/dynamic';
+import fileContents from '!!raw-loader!../../../../jest-fixture/packages/mock-package2/examples/example2';
+import Wrapper from '../../../../jest-fixture/package-example';
+
+const DynamicComponent = dynamic(import('../../../../jest-fixture/packages/mock-package2/examples/example2')
+.then(Components => {
+return () => ( 
+<Wrapper data={{"id":"mock-package2","packageName":"mock-package-2","isolatedPath":"/packages/mock-package2/examples/isolated/example2","pageTitle":"Example2"}} fileContents={fileContents}>
+      {
+        [{ 
+            name: 'default', 
+            component: <Components.default /> 
+          }, 
+          ...Object.keys(Components).filter(componentName => componentName !== 'default')
+          .map(componentName => {
+            const Component = Components[componentName];
+            return {
+              name: componentName,
+              component: <Component />
+            }
+          })
+        ]
+      }
+  </Wrapper>
+  )
+}));
+export default () => <DynamicComponent/>
+`;
+
+exports[`Generate pages package pages generation creates examples pages for each package 8`] = `
+import React from 'react';
+import dynamic from 'next/dynamic';
+import fileContents from '!!raw-loader!../../../../jest-fixture/packages/mock-package2/examples/example3';
+import Wrapper from '../../../../jest-fixture/package-example';
+
+const DynamicComponent = dynamic(import('../../../../jest-fixture/packages/mock-package2/examples/example3')
+.then(Components => {
+return () => ( 
+<Wrapper data={{"id":"mock-package2","packageName":"mock-package-2","isolatedPath":"/packages/mock-package2/examples/isolated/example3","pageTitle":"Example3"}} fileContents={fileContents}>
+      {
+        [{ 
+            name: 'default', 
+            component: <Components.default /> 
+          }, 
+          ...Object.keys(Components).filter(componentName => componentName !== 'default')
+          .map(componentName => {
+            const Component = Components[componentName];
+            return {
+              name: componentName,
+              component: <Component />
+            }
+          })
+        ]
+      }
+  </Wrapper>
+  )
+}));
+export default () => <DynamicComponent/>
+`;
+
+exports[`Generate pages package pages generation creates examples pages for each package 9`] = `
+import React from 'react';
+import Wrapper from '../../../../jest-fixture/item-list';
+
+export default () => (
+  <Wrapper data={{"id":"mock-package3","packageName":"mock-package-3","pagePath":"packages/mock-package3/examples/index.js","pageTitle":"Examples","pageType":"examples"}} />
+);
+`;
+
+exports[`Generate pages package pages generation creates examples pages for each package 10`] = `
+import React from 'react';
+import dynamic from 'next/dynamic';
+import fileContents from '!!raw-loader!../../../../jest-fixture/packages/mock-package3/examples/example1';
+import Wrapper from '../../../../jest-fixture/package-example';
+
+const DynamicComponent = dynamic(import('../../../../jest-fixture/packages/mock-package3/examples/example1')
+.then(Components => {
+return () => ( 
+<Wrapper data={{"id":"mock-package3","packageName":"mock-package-3","isolatedPath":"/packages/mock-package3/examples/isolated/example1","pageTitle":"Example1"}} fileContents={fileContents}>
+      {
+        [{ 
+            name: 'default', 
+            component: <Components.default /> 
+          }, 
+          ...Object.keys(Components).filter(componentName => componentName !== 'default')
+          .map(componentName => {
+            const Component = Components[componentName];
+            return {
+              name: componentName,
+              component: <Component />
+            }
+          })
+        ]
+      }
+  </Wrapper>
+  )
+}));
+export default () => <DynamicComponent/>
+`;
+
+exports[`Generate pages package pages generation creates examples pages for each package 11`] = `
+import React from 'react';
+import dynamic from 'next/dynamic';
+import fileContents from '!!raw-loader!../../../../jest-fixture/packages/mock-package3/examples/example2';
+import Wrapper from '../../../../jest-fixture/package-example';
+
+const DynamicComponent = dynamic(import('../../../../jest-fixture/packages/mock-package3/examples/example2')
+.then(Components => {
+return () => ( 
+<Wrapper data={{"id":"mock-package3","packageName":"mock-package-3","isolatedPath":"/packages/mock-package3/examples/isolated/example2","pageTitle":"Example2"}} fileContents={fileContents}>
+      {
+        [{ 
+            name: 'default', 
+            component: <Components.default /> 
+          }, 
+          ...Object.keys(Components).filter(componentName => componentName !== 'default')
+          .map(componentName => {
+            const Component = Components[componentName];
+            return {
+              name: componentName,
+              component: <Component />
+            }
+          })
+        ]
+      }
+  </Wrapper>
+  )
+}));
+export default () => <DynamicComponent/>
+`;
+
+exports[`Generate pages package pages generation creates examples pages for each package 12`] = `
+import React from 'react';
+import dynamic from 'next/dynamic';
+import fileContents from '!!raw-loader!../../../../jest-fixture/packages/mock-package3/examples/example3';
+import Wrapper from '../../../../jest-fixture/package-example';
+
+const DynamicComponent = dynamic(import('../../../../jest-fixture/packages/mock-package3/examples/example3')
+.then(Components => {
+return () => ( 
+<Wrapper data={{"id":"mock-package3","packageName":"mock-package-3","isolatedPath":"/packages/mock-package3/examples/isolated/example3","pageTitle":"Example3"}} fileContents={fileContents}>
+      {
+        [{ 
+            name: 'default', 
+            component: <Components.default /> 
+          }, 
+          ...Object.keys(Components).filter(componentName => componentName !== 'default')
+          .map(componentName => {
+            const Component = Components[componentName];
+            return {
+              name: componentName,
+              component: <Component />
+            }
+          })
+        ]
+      }
+  </Wrapper>
+  )
+}));
+export default () => <DynamicComponent/>
+`;
+
+exports[`Generate readme page at the root level creates a readme page for the root level file 1`] = `
+import React from 'react';
+import Component from '../jest-fixture/README.md';
+import Wrapper from '../jest-fixture/project-docs';
+
+export default () => (
+  <Wrapper data={{"key":"readme","pagePath":"readme.js","pageTitle":"readme"}}>
+      <Component />
+  </Wrapper>
+);
+`;
+
+exports[`readmes in the docs should generate a page for each child readme 1`] = `
+import React from 'react';
+import Component from '../../../../jest-fixture/docs/doc-3/readme.md';
+import Wrapper from '../../../../jest-fixture/project-docs';
+
+export default () => (
+  <Wrapper data={{"key":"docs","pagePath":"docs/doc-3/readme/index.js","pageTitle":"Doc 3"}}>
+      <Component />
+  </Wrapper>
+);
+`;
+
+exports[`readmes in the docs should generate a page for each child readme 2`] = `
+import React from 'react';
+import Component from '../../../../../jest-fixture/docs/doc-3/doc-3-2/README.md';
+import Wrapper from '../../../../../jest-fixture/project-docs';
+
+export default () => (
+  <Wrapper data={{"key":"docs","pagePath":"docs/doc-3/doc-3-2/README/index.js","pageTitle":"Doc 3 2"}}>
+      <Component />
+  </Wrapper>
+);
+`;

--- a/packages/website/src/bin/page-generator/index.js
+++ b/packages/website/src/bin/page-generator/index.js
@@ -31,10 +31,6 @@ const scanAndGenerate = (docs, docsPath, generatorConfig, name) => {
     const pagePath = path.join(docsPath, doc.id);
 
     if (doc.children) {
-      const readme = doc.children.find(
-        c => c.path && c.path.toLowerCase().match(/readme\.md$/),
-      );
-
       const docData = {
         key: name,
         id: doc.id,
@@ -43,14 +39,18 @@ const scanAndGenerate = (docs, docsPath, generatorConfig, name) => {
           pagePath: path.join(doc.id, child.id),
         })),
       };
-      if (readme) {
-        generateDocsHomePage(
-          path.join(pagePath, 'index.js'),
-          { ...docData, ...pageData },
-          generatorConfig,
-          'Documents',
-        );
 
+      generateDocsHomePage(
+        path.join(pagePath, 'index.js'),
+        { ...docData, ...pageData },
+        generatorConfig,
+        'Documents',
+      );
+
+      const readme = doc.children.find(
+        c => c.path && c.path.toLowerCase().match(/readme\.md$/),
+      );
+      if (readme) {
         generateDocFunc(
           path.join(pagePath, readme.id, 'index.js'),
           readme.path,
@@ -58,29 +58,13 @@ const scanAndGenerate = (docs, docsPath, generatorConfig, name) => {
           generatorConfig,
           titleCase(doc.id),
         );
-
-        return {
-          id: doc.id,
-          pagePath: path.join('/', pagePath, readme.id),
-          children: scanAndGenerate(
-            doc.children.filter(c => !(c.id.toLowerCase() === 'readme')),
-            path.join(docsPath, doc.id),
-            generatorConfig,
-            name,
-          ),
-        };
       }
-      generateDocsHomePage(
-        path.join(pagePath, 'index.js'),
-        { ...docData, ...pageData },
-        generatorConfig,
-        'Documents',
-      );
+
       return {
         id: doc.id,
-        pagePath: path.join('/', pagePath),
+        pagePath: path.join('/', pagePath, readme ? readme.id : ''),
         children: scanAndGenerate(
-          doc.children,
+          doc.children.filter(c => !(c.id.toLowerCase() === 'readme')),
           path.join(docsPath, doc.id),
           generatorConfig,
           name,

--- a/packages/website/src/bin/page-generator/test.js
+++ b/packages/website/src/bin/page-generator/test.js
@@ -278,6 +278,18 @@ describe('Generate pages', () => {
       ).toMatchSnapshot();
     });
 
+    it('creates an index/home page for each level of nesting', () => {
+      expect(
+        getOutput(path.join(pagesPath, 'docs', 'index.js')),
+      ).toMatchSnapshot();
+      expect(
+        getOutput(path.join(pagesPath, 'docs', 'doc-3', 'index.js')),
+      ).toMatchSnapshot();
+      expect(
+        getOutput(path.join(pagesPath, 'docs', 'doc-3', 'doc-3-2', 'index.js')),
+      ).toMatchSnapshot();
+    });
+
     describe('sitemap generation', () => {
       let docsSitemap;
 
@@ -515,6 +527,25 @@ describe('readmes in the docs', () => {
         pagePath: '/docs/doc-3/readme',
       },
     ]);
+
+    expect(
+      fs.existsSync(path.join(pagesPath, 'docs', 'doc-3', 'readme.js')),
+    ).toBe(false);
+    expect(
+      fs.existsSync(
+        path.join(pagesPath, 'docs', 'doc-3', 'doc-3-2', 'README.js'),
+      ),
+    ).toBe(false);
+  });
+  it('should generate a page for each child readme', () => {
+    expect(
+      getOutput(path.join(pagesPath, 'docs', 'doc-3', 'readme', 'index.js')),
+    ).toMatchSnapshot();
+    expect(
+      getOutput(
+        path.join(pagesPath, 'docs', 'doc-3', 'doc-3-2', 'README', 'index.js'),
+      ),
+    ).toMatchSnapshot();
   });
 });
 


### PR DESCRIPTION
I was looking at the page generation code as part of the metadata task and wanted to slightly refactor some of the code but after commenting out certain parts I found that they weren't covered by tests.

As part of adding test coverage I wanted to test the actual contents of the generated pages instead of only testing whether they exist. As a result, I've replaced all the tests that were testing whether the file exists to snapshot tests as this covers that both they exist + page contents. I've left a few `existsSync` checks for tests that *only* wanted to test existence.

FYI using snapshot tests here makes them a bit of an integration tests since technically the contents are the concern of the write-pages module, however, I think it's preferable to just snapshot test over mocking each page generation function and testing that those functions were called with certain parameters.

The main purpose of the tests are to catch unintentional modifications to pages as a result of any refactoring, which I plan to do as part of the metadata work.