### PR TITLE
AFP-343 Fix flaky cypress tests

### DIFF
--- a/packages/website/cypress/integration/navigation/packages.spec.js
+++ b/packages/website/cypress/integration/navigation/packages.spec.js
@@ -4,12 +4,12 @@ describe('Packages home page tests', () => {
   });
 
   // TODO
-  it('should navigate to to each package from the nav bar', () => {});
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('should navigate to to each package from the nav bar');
 
   it('should navigate to to each package from the packages table', () => {
     // Mock package 1
-    cy.get('table')
-      .get('a')
+    cy.get('table a')
       .contains('Mock Package1')
       .click();
     cy.url().should('include', '/packages/mock-package1');
@@ -24,8 +24,7 @@ describe('Packages home page tests', () => {
     cy.go('back');
 
     // Mock package 2
-    cy.get('table')
-      .get('a')
+    cy.get('table a')
       .contains('Mock Package2')
       .click();
 
@@ -41,8 +40,7 @@ describe('Packages home page tests', () => {
     cy.go('back');
 
     // Mock package 3
-    cy.get('table')
-      .get('a')
+    cy.get('table a')
       .contains('Mock Package3')
       .click();
 

--- a/packages/website/cypress/support/index.js
+++ b/packages/website/cypress/support/index.js
@@ -1,3 +1,13 @@
 Cypress.Commands.add('getTestElement', selector =>
   cy.get(`[data-testid=${selector}]`),
 );
+
+/**
+ * Override the visit command to also wait until the client-side code has loaded.
+ * This prevents flakiness involving cypress retrieving elements in the SSR'd DOM
+ * that then become stale due to the client (React) flushing the DOM with fresh contents.
+ * See https://github.com/cypress-io/cypress/issues/695#issuecomment-333154635
+ */
+Cypress.Commands.overwrite('visit', (originalFn, url, options) => {
+  return originalFn(url, options).get('body[data-client-loaded]');
+});

--- a/packages/website/default-pages/_app.tsx
+++ b/packages/website/default-pages/_app.tsx
@@ -22,6 +22,17 @@ export default class MyApp extends App<Props> {
     return { pageProps };
   }
 
+  componentDidMount() {
+    /**
+     * Set a marker on body indicating that we've rendered on the client side (componentDidMount does not execute on the server).
+     * This is required for our cypress tests to wait before trying to fetch elements otherwise they may become stale if they are
+     * fetched before React renders over the server-side DOM.
+     * See https://github.com/cypress-io/cypress/issues/695#issuecomment-333158645
+     */
+    // eslint-disable-next-line no-undef
+    document.body.dataset.clientLoaded = 'true';
+  }
+
   render() {
     const { Component, pageProps } = this.props;
 


### PR DESCRIPTION
 Flaky tests have (hopefully) been fixed by adding a cypress guard to wait until React has rendered on the client

Also fixed tests in packages.spec.js that were selecting the wrong anchor elements.