### PR TITLE
AFP-345 Reverse title/sitename order

### DIFF
--- a/.changeset/popular-cycles-arrive/changes.json
+++ b/.changeset/popular-cycles-arrive/changes.json
@@ -1,0 +1,4 @@
+{
+  "releases": [{ "name": "@brisk-docs/website", "type": "patch" }],
+  "dependents": []
+}

--- a/.changeset/popular-cycles-arrive/changes.md
+++ b/.changeset/popular-cycles-arrive/changes.md
@@ -1,0 +1,1 @@
+Update document title to have trailing site name suffix rather than prefix

--- a/packages/website/cypress/integration/pages/docs-page.spec.js
+++ b/packages/website/cypress/integration/pages/docs-page.spec.js
@@ -1,11 +1,11 @@
 describe('Docs page tests', () => {
   it('has the correct page title', () => {
     cy.visit('/docs/guides/nifty-tricks/staying-at-netherfield');
-    cy.title().should('eq', 'Dummy Data Docs - Staying At Netherfield');
+    cy.title().should('eq', 'Staying At Netherfield - Dummy Data Docs');
   });
 
   it('has the correct page title for page with custom title', () => {
     cy.visit('/docs/guides/how-to-be-accomplished');
-    cy.title().should('eq', 'Dummy Data Docs - Being accomplished');
+    cy.title().should('eq', 'Being accomplished - Dummy Data Docs');
   });
 });

--- a/packages/website/cypress/integration/pages/package-changelog.spec.js
+++ b/packages/website/cypress/integration/pages/package-changelog.spec.js
@@ -5,7 +5,7 @@ describe('Package changelog page tests', () => {
     });
 
     it('has the correct page title', () => {
-      cy.title().should('eq', 'Dummy Data Docs - Changelog');
+      cy.title().should('eq', 'Changelog - Dummy Data Docs');
     });
   });
 
@@ -15,7 +15,7 @@ describe('Package changelog page tests', () => {
     });
 
     it('has the correct page title', () => {
-      cy.title().should('eq', 'Dummy Data Docs - Changelog');
+      cy.title().should('eq', 'Changelog - Dummy Data Docs');
     });
   });
 });

--- a/packages/website/cypress/integration/pages/package-docs-home.spec.js
+++ b/packages/website/cypress/integration/pages/package-docs-home.spec.js
@@ -4,6 +4,6 @@ describe('Package docs home page tests', () => {
   });
 
   it('has the correct page title', () => {
-    cy.title().should('eq', 'Dummy Data Docs - Documents');
+    cy.title().should('eq', 'Documents - Dummy Data Docs');
   });
 });

--- a/packages/website/cypress/integration/pages/package-docs.spec.js
+++ b/packages/website/cypress/integration/pages/package-docs.spec.js
@@ -1,11 +1,11 @@
 describe('Package docs page tests', () => {
   it('has the correct page title', () => {
     cy.visit('/packages/mock-package2/docs/extended-info');
-    cy.title().should('eq', 'Dummy Data Docs - Extended Info');
+    cy.title().should('eq', 'Extended Info - Dummy Data Docs');
   });
 
   it('has the correct page title with custom page title', () => {
     cy.visit('/packages/mock-package1/docs/extended-info');
-    cy.title().should('eq', 'Dummy Data Docs - Extended Information');
+    cy.title().should('eq', 'Extended Information - Dummy Data Docs');
   });
 });

--- a/packages/website/cypress/integration/pages/package-example.spec.js
+++ b/packages/website/cypress/integration/pages/package-example.spec.js
@@ -4,6 +4,6 @@ describe('Package example page tests', () => {
   });
 
   it('has the correct page title', () => {
-    cy.title().should('eq', 'Dummy Data Docs - Example1');
+    cy.title().should('eq', 'Example1 - Dummy Data Docs');
   });
 });

--- a/packages/website/cypress/integration/pages/package-examples-home.spec.js
+++ b/packages/website/cypress/integration/pages/package-examples-home.spec.js
@@ -4,6 +4,6 @@ describe('Package examples home page tests', () => {
   });
 
   it('has the correct page title', () => {
-    cy.title().should('eq', 'Dummy Data Docs - Examples');
+    cy.title().should('eq', 'Examples - Dummy Data Docs');
   });
 });

--- a/packages/website/cypress/integration/pages/package-home.spec.js
+++ b/packages/website/cypress/integration/pages/package-home.spec.js
@@ -4,6 +4,6 @@ describe('Package home page tests', () => {
   });
 
   it('has the correct page title', () => {
-    cy.title().should('eq', 'Dummy Data Docs - Mock Package1');
+    cy.title().should('eq', 'Mock Package1 - Dummy Data Docs');
   });
 });

--- a/packages/website/src/components/page-title.tsx
+++ b/packages/website/src/components/page-title.tsx
@@ -10,7 +10,7 @@ const PageTitle = ({ title }: Props) => (
   <Meta.Consumer>
     {({ siteName }: { siteName: string }) => (
       <Head>
-        <title>{title ? `${siteName} - ${title}` : siteName}</title>
+        <title>{title ? `${title} - ${siteName}` : siteName}</title>
       </Head>
     )}
   </Meta.Consumer>


### PR DESCRIPTION
Previously we were prefixing the page title with sitename for the document title. This resulted in the site name taking up the majority of the space in a window tab title making it hard to distinguish between different pages.

This reverses the order to have the page title first and site name second.