### PR TITLE
AFP-343 Fix link button remounting on each render

### DIFF
--- a/.changeset/neat-planes-think/changes.json
+++ b/.changeset/neat-planes-think/changes.json
@@ -1,0 +1,4 @@
+{
+  "releases": [{ "name": "@brisk-docs/website", "type": "patch" }],
+  "dependents": []
+}

--- a/.changeset/neat-planes-think/changes.md
+++ b/.changeset/neat-planes-think/changes.md
@@ -1,0 +1,1 @@
+Fix button links from remounting on component re-renders such as on hover

--- a/packages/website/src/components/link-button.test.tsx
+++ b/packages/website/src/components/link-button.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import Link from 'next/link';
+
+import LinkButton from './link-button';
+
+describe('LinkButton', () => {
+  it('should render an anchor', () => {
+    const wrapper = mount(<LinkButton href="/foo">Foo</LinkButton>);
+
+    const anchor = wrapper.find('a');
+    expect(anchor).toHaveLength(1);
+    expect(anchor.prop('href')).toEqual('/foo');
+  });
+
+  it('should render a next Link component', () => {
+    const wrapper = mount(<LinkButton href="/foo">Foo</LinkButton>);
+
+    const link = wrapper.find(Link);
+    expect(link).toHaveLength(1);
+    expect(link.prop('href')).toEqual('/foo');
+  });
+
+  it('should not remount its contents across re-renders', () => {
+    const wrapper = mount(<LinkButton href="/foo">Foo</LinkButton>);
+
+    const anchorBefore = wrapper.find('a').instance();
+    const linkBefore = wrapper.find(Link).instance();
+
+    // Triggers a re-render
+    wrapper.setProps({});
+
+    const anchorAfter = wrapper.find('a').instance();
+    const linkAfter = wrapper.find(Link).instance();
+
+    expect(anchorBefore).toBe(anchorAfter);
+    // Note: doing expect(linkBefore).toBe(linkAfter) causes infinite loop (OOM) in jests object equality reporting tool
+    // since the component instances are recursive.
+    expect(linkBefore === linkAfter).toBe(true);
+  });
+});

--- a/packages/website/src/components/link-button.tsx
+++ b/packages/website/src/components/link-button.tsx
@@ -11,26 +11,23 @@ import * as React from 'react';
 import Button from '@atlaskit/button';
 import Link from 'next/link';
 
-const LinkButton = (props: {
-  children: React.ReactChild;
+/** Note: Render components need to be defined standalone. Defining them inline will create a
+ * new function reference each time and cause re-mounts on each render. */
+const LinkButtonRenderComponent = ({
+  href,
+  children,
+  ...rest
+}: {
   href: string;
-  appearance: string;
+  children: React.ReactNode;
 }) => (
-  <Button
-    {...props}
-    component={({
-      href,
-      children,
-      ...rest
-    }: {
-      href: string;
-      children: React.ReactNode;
-    }) => (
-      <Link href={href}>
-        <a {...rest}>{children}</a>
-      </Link>
-    )}
-  />
+  <Link href={href}>
+    <a {...rest}>{children}</a>
+  </Link>
+);
+
+const LinkButton = (props: typeof Button) => (
+  <Button {...props} component={LinkButtonRenderComponent} />
 );
 
 export default LinkButton;


### PR DESCRIPTION
This is the root cause issue of the flaky test, the link button component remounts its contents on re-render due to an inline render component.

